### PR TITLE
Story | Call of Duty: Modern Warfare — October 2019; Official

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -21,5 +21,8 @@ The undead are rising in the latest Operation, as Zombies spread across all mode
 #### Days of Summer event (Call of Duty®: Black Ops 4)
 No, it’s not a music festival, I’m not cool enough to go to those.. ([Friend link](https://medium.com/future-vision/days-of-summer-event-call-of-duty-black-ops-4-325d4728d152?source=friends_link&sk=2f62dc355ce18eabe7ea6fef97bf3a3d))
 
+#### Call of Duty: Modern Warfare — October 2019; Official
+Prepare to go dark. Modern Warfare® is back, and ready to deploy October 25 ([Friend link](https://medium.com/future-vision/call-of-duty-modern-warfare-october-2019-official-9a31a4623110?source=friends_link&sk=d45609bc2ff935b2195cf79b003aa1b7))
+
 #### Black Ops 4 *UPDATE* leaves you dripping wet.
 Hydro Busts, micro-transactions out the wazoo & Zombies gets screwed (again) — a Brief Overview of Operation Spectre Rising ([Friend link](https://medium.com/future-vision/black-ops-4-update-leaves-you-dripping-wet-ec6e8292fa93?source=friends_link&sk=4c181c194259a6b34e59ec10d39c9d80))


### PR DESCRIPTION
Bug: missing 

#### Call of Duty: Modern Warfare — October 2019; Official
Prepare to go dark. Modern Warfare® is back, and ready to deploy October 25 ([Friend link](https://medium.com/future-vision/call-of-duty-modern-warfare-october-2019-official-9a31a4623110?source=friends_link&sk=d45609bc2ff935b2195cf79b003aa1b7))